### PR TITLE
Remove numpy dependency

### DIFF
--- a/ida_db/ida_db.py
+++ b/ida_db/ida_db.py
@@ -97,9 +97,7 @@ class pglogger(object):
         if type(channels)==str:
             channels_string = channels
         else:
-            import numpy
-            channels_string = numpy.array2string(channels,separator=',')
-            channels_string = channels_string[1:-1] # remove brackets
+            channels_string = ','.join(map(str, channels))
 
         if not time:
             time_string = "NOW() AT TIME ZONE 'America/New_York'"

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(name='ida-db',
       author_email='info@project-ida.org',
       description='Interface to Timescale PostgreSQL database',
       packages=find_packages(),
-      install_requires=['psycopg2','numpy'],
+      install_requires=['psycopg2'],
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='ida-db',
-      version='0.1.2',
+      version='0.1.3',
       url='https://github.com/project-ida/ida-db',
       license='MIT',
       author='Project Ida',


### PR DESCRIPTION
This PR, removes numpy dependency in favour of native join function inside the `log` function of the `pglogger` class.

I have done some tests using the following inputs as the channels parameter:
- String of numbers like `"1,2,3,4"`
- Python list of numbers like `[1,2,3,4]`
- Numpy array of numbers like `numpy.array([1,2,3,4])`

The `log` function appears to behave as expected, but @fwmetzler could you take another look because you are more familiar with the data structures.
